### PR TITLE
Cap StatsModels at 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ FixedEffectModels = "≥ 0.7.1"
 FixedEffects = "≥ 0.1.1"
 LeastSquaresOptim = "≥ 0.7.0"
 StatsBase = "≥ 0.22.0"
-StatsModels = "≥ 0.2.4"
+StatsModels = "~0.2.4, 0.3, 0.4, 0.5"
 julia = "≥ 0.7.0"
 
 [extras]


### PR DESCRIPTION
StatsModels v0.6 is a breaking change: [https://discourse.julialang.org/t/psa-breaking-changes-in-statsmodels-v0-6-0-terms-2-0-son-of-terms/]

I'll also submit a PR to General to add the cap to all older versions as well.